### PR TITLE
Add support for Dropbox's integrated file picker

### DIFF
--- a/pickit/src/main/java/com/hbisoft/pickit/PickiT.java
+++ b/pickit/src/main/java/com/hbisoft/pickit/PickiT.java
@@ -122,7 +122,7 @@ public class PickiT implements CallBackTask{
 
     // Check different providers
     private boolean isDropBox(Uri uri) {
-        return String.valueOf(uri).toLowerCase().contains("content://com.dropbox.android");
+        return String.valueOf(uri).toLowerCase().contains("content://com.dropbox.");
     }
     private boolean isGoogleDrive(Uri uri) {
         return String.valueOf(uri).toLowerCase().contains("com.google.android.apps");


### PR DESCRIPTION
Dropbox has 2 document providers. The one, which opens in a Dropbox file picker, returns `content://com.dropbox.android.FileCache/filecache/[...]` and the other, which is integrated with Android's file picker, returns `content://com.dropbox.product.android.dbapp.document_provider.documents/document/[...]`. `content://com.dropbox.android` won't pick up `content://com.dropbox.product.android` so I changed it to `content://com.dropbox.` in order to match both document providers.