### PR TITLE
deleteTemporaryFile - support for fragments 

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/app" />
+            <option value="$PROJECT_DIR$/pickit" />
+          </set>
+        </option>
         <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If the selected file was from Dropbox,Google Drive, OneDrive or an unknown file 
 It is your responsibility to delete the file when you are done with it, by calling:
 
 ```java
-pickiT.deleteTemporaryFile();
+PickiT.deleteTemporaryFile(context);
 ```
 This can be done in `onBackPressed` and `onDestroy`, as shown below:
 
@@ -129,7 +129,7 @@ public void onDestroy() {
 }
 ```
 
-If you do not call `pickiT.deleteTemporaryFile();`, the file will remain in the above mentioned folder and will be overwritten each time you select a new file from Dropbox,Google Drive, OneDrive or an unknown file provider.
+If you do not call `PickiT.deleteTemporaryFile(context);`, the file will remain in the above mentioned folder and will be overwritten each time you select a new file from Dropbox,Google Drive, OneDrive or an unknown file provider.
 
 Manifest
 ---

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This can be done in `onBackPressed` and `onDestroy`, as shown below:
 ```java
 @Override
 public void onBackPressed() {
-    pickiT.deleteTemporaryFile();
+    PickiT.deleteTemporaryFile(this);
     super.onBackPressed();
 }
 
@@ -124,7 +124,7 @@ public void onBackPressed() {
 public void onDestroy() {
     super.onDestroy();
     if (!isChangingConfigurations()) {
-        pickiT.deleteTemporaryFile();
+        PickiT.deleteTemporaryFile(this);
     }
 }
 ```

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,10 +20,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation project(path: ':pickit')
 }

--- a/app/src/main/java/com/hbisoft/pickitexample/MainActivity.java
+++ b/app/src/main/java/com/hbisoft/pickitexample/MainActivity.java
@@ -6,22 +6,21 @@ import android.app.ProgressDialog;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.os.Environment;
-
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.view.ContextThemeWrapper;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.os.Bundle;
+import android.os.Environment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.view.ContextThemeWrapper;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 import com.hbisoft.pickit.PickiT;
 import com.hbisoft.pickit.PickiTCallbacks;
@@ -38,6 +37,10 @@ public class MainActivity extends AppCompatActivity implements PickiTCallbacks {
     //Views
     Button button_pick;
     TextView pickitTv, originalTv, originalTitle, pickitTitle;
+    ProgressBar mProgressBar;
+    TextView percentText;
+    ProgressDialog progressBar;
+    private AlertDialog mdialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -79,6 +82,28 @@ public class MainActivity extends AppCompatActivity implements PickiTCallbacks {
             }
         });
     }
+
+    //
+    //  PickiT Listeners
+    //
+    //  The listeners can be used to display a Dialog when a file is selected from Dropbox/Google Drive or OnDrive.
+    //  The listeners are callbacks from an AsyncTask that creates a new File of the original in /storage/emulated/0/Android/data/your.package.name/files/Temp/
+    //
+    //  PickiTonUriReturned()
+    //  When selecting a file from Google Drive, for example, the Uri will be returned before the file is available(if it has not yet been cached/downloaded).
+    //  Google Drive will first have to download the file before we have access to it.
+    //  This can be used to let the user know that we(the application), are waiting for the file to be returned.
+    //
+    //  PickiTonStartListener()
+    //  This will be call once the file creations starts and will only be called if the selected file is not local
+    //
+    //  PickiTonProgressUpdate(int progress)
+    //  This will return the progress of the file creation (in percentage) and will only be called if the selected file is not local
+    //
+    //  PickiTonCompleteListener(String path, boolean wasDriveFile)
+    //  If the selected file was from Dropbox/Google Drive or OnDrive, then this will be called after the file was created.
+    //  If the selected file was a local file then this will be called directly, returning the path as a String
+    //  Additionally, a boolean will be returned letting you know if the file selected was from Dropbox/Google Drive or OnDrive.
 
     private void openGallery() {
         //  first check if permissions was granted
@@ -143,33 +168,6 @@ public class MainActivity extends AppCompatActivity implements PickiTCallbacks {
         }
     }
 
-    //
-    //  PickiT Listeners
-    //
-    //  The listeners can be used to display a Dialog when a file is selected from Dropbox/Google Drive or OnDrive.
-    //  The listeners are callbacks from an AsyncTask that creates a new File of the original in /storage/emulated/0/Android/data/your.package.name/files/Temp/
-    //
-    //  PickiTonUriReturned()
-    //  When selecting a file from Google Drive, for example, the Uri will be returned before the file is available(if it has not yet been cached/downloaded).
-    //  Google Drive will first have to download the file before we have access to it.
-    //  This can be used to let the user know that we(the application), are waiting for the file to be returned.
-    //
-    //  PickiTonStartListener()
-    //  This will be call once the file creations starts and will only be called if the selected file is not local
-    //
-    //  PickiTonProgressUpdate(int progress)
-    //  This will return the progress of the file creation (in percentage) and will only be called if the selected file is not local
-    //
-    //  PickiTonCompleteListener(String path, boolean wasDriveFile)
-    //  If the selected file was from Dropbox/Google Drive or OnDrive, then this will be called after the file was created.
-    //  If the selected file was a local file then this will be called directly, returning the path as a String
-    //  Additionally, a boolean will be returned letting you know if the file selected was from Dropbox/Google Drive or OnDrive.
-
-    ProgressBar mProgressBar;
-    TextView percentText;
-    private AlertDialog mdialog;
-    ProgressDialog progressBar;
-
     @Override
     public void PickiTonUriReturned() {
         progressBar = new ProgressDialog(this);
@@ -180,7 +178,7 @@ public class MainActivity extends AppCompatActivity implements PickiTCallbacks {
 
     @Override
     public void PickiTonStartListener() {
-        if (progressBar.isShowing()){
+        if (progressBar.isShowing()) {
             progressBar.cancel();
         }
         final AlertDialog.Builder mPro = new AlertDialog.Builder(new ContextThemeWrapper(this, R.style.myDialog));
@@ -220,11 +218,11 @@ public class MainActivity extends AppCompatActivity implements PickiTCallbacks {
         }
 
         //  Check if it was a Drive/local/unknown provider file and display a Toast
-        if (wasDriveFile){
+        if (wasDriveFile) {
             showLongToast("Drive file was selected");
-        }else if (wasUnknownProvider){
+        } else if (wasUnknownProvider) {
             showLongToast("File was selected from unknown provider");
-        }else {
+        } else {
             showLongToast("Local file was selected");
         }
 
@@ -238,7 +236,7 @@ public class MainActivity extends AppCompatActivity implements PickiTCallbacks {
             originalTv.setVisibility(View.VISIBLE);
             pickitTitle.setVisibility(View.VISIBLE);
             pickitTv.setVisibility(View.VISIBLE);
-        }else {
+        } else {
             showLongToast("Error, please see the log..");
             pickitTv.setVisibility(View.VISIBLE);
             pickitTv.setText(reason);
@@ -253,7 +251,7 @@ public class MainActivity extends AppCompatActivity implements PickiTCallbacks {
     //  Deleting the temporary file if it exists
     @Override
     public void onBackPressed() {
-        pickiT.deleteTemporaryFile();
+        PickiT.deleteTemporaryFile(this);
         super.onBackPressed();
     }
 
@@ -264,7 +262,7 @@ public class MainActivity extends AppCompatActivity implements PickiTCallbacks {
     public void onDestroy() {
         super.onDestroy();
         if (!isChangingConfigurations()) {
-            pickiT.deleteTemporaryFile();
+            PickiT.deleteTemporaryFile(this);
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 15 06:48:30 SAST 2019
+#Thu Jul 30 10:56:34 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/pickit/build.gradle
+++ b/pickit/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
-
-
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
@@ -25,9 +23,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-
-    implementation 'androidx.appcompat:appcompat:1.0.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    testImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/pickit/src/main/java/com/hbisoft/pickit/PickiT.java
+++ b/pickit/src/main/java/com/hbisoft/pickit/PickiT.java
@@ -103,20 +103,22 @@ public class PickiT implements CallBackTask{
     }
 
     // Create a new file from the Uri that was selected
-    private void downloadFile(Uri uri){
+    private void downloadFile(Uri uri) {
         asyntask = new DownloadAsyncTask(uri, context, this, mActivity);
         asyntask.execute();
     }
 
-    // End the "copying" of the file
-    public void cancelTask(){
-        if (asyntask!=null){
-            asyntask.cancel(true);
-            deleteTemporaryFile();
+    // Delete the temporary folder
+    public static void deleteTemporaryFile(Context context) {
+        File folder = context.getExternalFilesDir("Temp");
+        if (folder != null) {
+            if (deleteDirectory(folder)) {
+                Log.i("PickiT ", " deleteDirectory was called");
+            }
         }
     }
 
-    public boolean wasLocalFileSelected(Uri uri){
+    public boolean wasLocalFileSelected(Uri uri) {
         return !isDropBox(uri) && !isGoogleDrive(uri) && !isOneDrive(uri);
     }
 
@@ -165,18 +167,8 @@ public class PickiT implements CallBackTask{
         }
     }
 
-    // Delete the temporary folder
-    public void deleteTemporaryFile(){
-        File folder = context.getExternalFilesDir("Temp");
-        if (folder != null) {
-            if (deleteDirectory(folder)){
-                Log.i("PickiT "," deleteDirectory was called");
-            }
-        }
-    }
-
-    private boolean deleteDirectory(File path) {
-        if(path.exists()) {
+    private static boolean deleteDirectory(File path) {
+        if (path.exists()) {
             File[] files = path.listFiles();
             if (files == null) {
                 return false;
@@ -192,7 +184,14 @@ public class PickiT implements CallBackTask{
                 }
             }
         }
-        return(path.delete());
+        return (path.delete());
     }
 
+    // End the "copying" of the file
+    public void cancelTask() {
+        if (asyntask != null) {
+            asyntask.cancel(true);
+            deleteTemporaryFile(context);
+        }
+    }
 }


### PR DESCRIPTION
- Provided support for fragments 
- onBackPressed() && isChangingConfigurations() not available on the fragment, so remove temp file facility given to user and user can remove temp file from anywhere when needed like when splash screen called and remove temp files.
- Refer commit text