### PR TITLE
Make path nullable to prevent Kotlin crash

### DIFF
--- a/app/src/main/java/com/hbisoft/pickitexample/MainActivity.java
+++ b/app/src/main/java/com/hbisoft/pickitexample/MainActivity.java
@@ -9,6 +9,7 @@ import android.os.Build;
 import android.os.Environment;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.core.app.ActivityCompat;
@@ -213,7 +214,7 @@ public class MainActivity extends AppCompatActivity implements PickiTCallbacks {
     }
 
     @Override
-    public void PickiTonCompleteListener(String path, boolean wasDriveFile, boolean wasUnknownProvider, boolean wasSuccessful, String reason) {
+    public void PickiTonCompleteListener(@Nullable String path, boolean wasDriveFile, boolean wasUnknownProvider, boolean wasSuccessful, String reason) {
 
         if (mdialog != null && mdialog.isShowing()) {
             mdialog.cancel();

--- a/pickit/src/main/java/com/hbisoft/pickit/PickiTCallbacks.java
+++ b/pickit/src/main/java/com/hbisoft/pickit/PickiTCallbacks.java
@@ -1,8 +1,10 @@
 package com.hbisoft.pickit;
 
+import androidx.annotation.Nullable;
+
 public interface PickiTCallbacks {
     void PickiTonUriReturned();
     void PickiTonStartListener();
     void PickiTonProgressUpdate(int progress);
-    void PickiTonCompleteListener(String path, boolean wasDriveFile, boolean wasUnknownProvider, boolean wasSuccessful, String Reason);
+    void PickiTonCompleteListener(@Nullable String path, boolean wasDriveFile, boolean wasUnknownProvider, boolean wasSuccessful, String Reason);
 }


### PR DESCRIPTION
I used this library on Kotlin project, it works very well but there is a small problem. The application is crashing when user picks a Contact. I looked your code and the problem was the "path" variable. As you know Kotlin is null safety but in this library "path" library is not nullable . To fix this problem i made "path" variable nullable to prevent crash.