### PR TITLE
Fix some uri paths being parsed incorrectly

### DIFF
--- a/pickit/src/main/java/com/hbisoft/pickit/Utils.java
+++ b/pickit/src/main/java/com/hbisoft/pickit/Utils.java
@@ -141,26 +141,20 @@ class Utils {
     }
 
     private static String getSubFolders(Uri uri) {
-        String replaceChars = String.valueOf(uri).replace("%2F", "/").replace("%20", " ").replace("%3A",":");
-        String[] bits = replaceChars.split("/");
-        String sub5 = bits[bits.length - 2];
-        String sub4 = bits[bits.length - 3];
-        String sub3 = bits[bits.length - 4];
-        String sub2 = bits[bits.length - 5];
-        String sub1 = bits[bits.length - 6];
-        if (sub1.equals("Download")){
-            return sub2+"/"+sub3+"/"+sub4+"/"+sub5+"/";
-        }
-        else if (sub2.equals("Download")){
-            return sub3+"/"+sub4+"/"+sub5+"/";
-        }
-        else if (sub3.equals("Download")){
-            return sub4+"/"+sub5+"/";
-        }
-        else if (sub4.equals("Download")){
-            return sub5+"/";
-        }
-        else {
+        String decodedPath = Uri.decode(String.valueOf(uri));
+        if (decodedPath == null)
+            return "";
+        int beginIndex = decodedPath.indexOf("Download/");
+        if (beginIndex == -1)
+            return "";
+        beginIndex += "Download/".length();
+        int endIndex = decodedPath.lastIndexOf("/");
+        if (endIndex == -1)
+            return "";
+        endIndex += 1;
+        try {
+            return decodedPath.substring(beginIndex, endIndex);
+        } catch (IndexOutOfBoundsException e) {
             return "";
         }
     }


### PR DESCRIPTION
When the uri is of "RawDownloadsDocument" and it has subfolder whose name contains non-Ascii characters, the subfolder name will not be parsed correctly.
For example, "/storage/emulated/0/Download/❤.mp4" and "/storage/emulated/0/Download/subfolder/example.mp4" will be parsed correctly, but "/storage/emulated/0/Download/subfolder❤/example.mp4" will be parsed as "/storage/emulated/0/Download/subfolder%E2%9D%A4/example.mp4".